### PR TITLE
Fixed BB command death persistence

### DIFF
--- a/src/main/java/rocks/boltsandnuts/bbtweaks/command/CommandBB.java
+++ b/src/main/java/rocks/boltsandnuts/bbtweaks/command/CommandBB.java
@@ -29,10 +29,16 @@ public class CommandBB extends CommandBase {
 		return;
 	}
 
-	public static void giveBreakBit(ICommandSender command) {
-		EntityPlayer player = command.getEntityWorld().getPlayerEntityByName(
-				command.getCommandSenderName());
-		NBTTagCompound data = player.getEntityData();
+	public static void giveBreakBit(ICommandSender sender) {
+		if(!(sender instanceof EntityPlayer))
+		{
+			sender.addChatMessage(new ChatComponentTranslation(
+					"You must be a player to use this command."));
+			return;
+		}
+		
+		EntityPlayer player = (EntityPlayer) sender;
+		NBTTagCompound data = player.getEntityData().getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG);
 		long timeNoSee = data.getLong("lastBB");
 		long time = System.currentTimeMillis();
 		if (time - timeNoSee < cooldown) {


### PR DESCRIPTION
Added check for player source and used casting to player entity.
Used the EntityPlayer.PERSISTED_NBT_TAG to store data.
