### PR TITLE
Made BB command nicer for frequent claimers

### DIFF
--- a/src/main/java/rocks/boltsandnuts/bbtweaks/ConfigHandler.java
+++ b/src/main/java/rocks/boltsandnuts/bbtweaks/ConfigHandler.java
@@ -30,6 +30,7 @@ public class ConfigHandler {
         config.addCustomCategoryComment(exampleSection, "Reserved for Future use");
 //        config.addCustomCategoryComment(generation, "This section contains all settings regarding ore generation.");
         CommandBB.cooldown = config.get(exampleSection, "BreakbitCooldown",1000*60*60*24).getInt();
+        CommandBB.maxBreakbits = config.get(exampleSection, "BreakbitMaximum", 32, "[1,64] Threshold for breakbit reset.").getInt();
         exampleOption = config.get(exampleSection, "notReallyAnOption", true, "if you choose not to decide, you still have made a choice.").getBoolean(exampleOption);
         config.save();
     }


### PR DESCRIPTION
Instead of resetting to the current time, the command will move forward
by the number of Breakbits granted \* cooldown per Breakbit.

For new players, and for players that miss more than 32 claims
(configurable), the time will still be reset.
